### PR TITLE
Add Inter font and vault management mockups

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,7 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: Arial, Helvetica, sans-serif;
+  --font-sans: 'Inter', sans-serif;
   --font-mono: "Courier New", monospace;
 }
 
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import { VaultCard } from "@/components/vault/VaultCard";
-import { vaults, Vault } from "@/components/vault/vaults";
+import { vaults, Vault, Asset } from "@/components/vault/vaults";
 
 interface LogEntry {
   timestamp: string;
@@ -11,7 +11,32 @@ interface LogEntry {
 }
 
 export default function Dashboard() {
+  const [data, setData] = useState<Vault[]>(vaults);
   const [logs, setLogs] = useState<LogEntry[]>([]);
+
+  const updatePrice = (id: string, price: number) => {
+    setData((d) =>
+      d.map((v) =>
+        v.id === id
+          ? { ...v, price, lastPriceUpdate: new Date().toISOString() }
+          : v
+      )
+    );
+  };
+
+  const updateComposition = (id: string, comp: Asset[]) => {
+    setData((d) => d.map((v) => (v.id === id ? { ...v, composition: comp } : v)));
+  };
+
+  const rebalance = (id: string) => {
+    setData((d) =>
+      d.map((v) =>
+        v.id === id
+          ? { ...v, staked: 0, lastRebalance: new Date().toISOString() }
+          : v
+      )
+    );
+  };
 
   function handleAction(action: string, vault: Vault) {
     const hash = "0x" + Math.random().toString(16).slice(2, 10);
@@ -26,8 +51,15 @@ export default function Dashboard() {
     <div className="min-h-screen p-6 md:p-10 space-y-6 font-sans">
       <h1 className="text-2xl font-semibold">Vault overview</h1>
       <div className="grid gap-4">
-        {vaults.map((v) => (
-          <VaultCard key={v.id} vault={v} onAction={handleAction} />
+        {data.map((v) => (
+          <VaultCard
+            key={v.id}
+            vault={v}
+            onAction={handleAction}
+            onUpdatePrice={updatePrice}
+            onRebalance={rebalance}
+            onUpdateComposition={updateComposition}
+          />
         ))}
       </div>
 

--- a/src/components/vault/VaultCard.tsx
+++ b/src/components/vault/VaultCard.tsx
@@ -1,13 +1,54 @@
-import { Vault } from "./vaults";
+import { useState } from "react";
+import { Vault, Asset } from "./vaults";
 import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 
 interface VaultCardProps {
   vault: Vault;
   onAction: (action: string, vault: Vault) => void;
+  onUpdatePrice: (id: string, price: number) => void;
+  onRebalance: (id: string) => void;
+  onUpdateComposition: (id: string, comp: Asset[]) => void;
 }
 
-export function VaultCard({ vault, onAction }: VaultCardProps) {
+export function VaultCard({
+  vault,
+  onAction,
+  onUpdatePrice,
+  onRebalance,
+  onUpdateComposition,
+}: VaultCardProps) {
+  const [editingPrice, setEditingPrice] = useState(false);
+  const [priceValue, setPriceValue] = useState(vault.price.toString());
+
+  const [editingComp, setEditingComp] = useState(false);
+  const [compRows, setCompRows] = useState<Asset[]>(vault.composition);
+
+  const addRow = () =>
+    setCompRows((r) => [...r, { symbol: "", allocation: 0 }]);
+  const updateRow = (i: number, field: keyof Asset, value: string) => {
+    setCompRows((rows) =>
+      rows.map((r, idx) => (idx === i ? { ...r, [field]: value } : r))
+    );
+  };
+  const removeRow = (i: number) =>
+    setCompRows((rows) => rows.filter((_, idx) => idx !== i));
+
+  const savePrice = () => {
+    onUpdatePrice(vault.id, parseFloat(priceValue));
+    onAction("update_price", vault);
+    setEditingPrice(false);
+  };
+
+  const saveComp = () => {
+    onUpdateComposition(
+      vault.id,
+      compRows.map((r) => ({ ...r, allocation: Number(r.allocation) }))
+    );
+    onAction("update_composition", vault);
+    setEditingComp(false);
+  };
+
   return (
     <Sheet>
       <div className="border rounded-md p-4 flex justify-between items-center">
@@ -22,18 +63,106 @@ export function VaultCard({ vault, onAction }: VaultCardProps) {
       <SheetContent className="flex flex-col gap-4" side="right">
         <div className="font-semibold text-lg mb-2">{vault.name}</div>
         <div className="text-sm">APY: {vault.apy}%</div>
+        <div className="text-sm">Price: {vault.price}</div>
         <div className="text-sm">Last price update: {vault.lastPriceUpdate}</div>
         <div className="text-sm">Last rebalance: {vault.lastRebalance}</div>
-        <div className="mt-4 flex flex-col gap-2">
-          <Button onClick={() => onAction("update_price", vault)}>Update price</Button>
-          <Button onClick={() => onAction("rebalance", vault)}>Rebalance now</Button>
-          <Button onClick={() => onAction("update_composition", vault)}>
-            Update composition
-          </Button>
-          <SheetClose asChild>
-            <Button variant="secondary">Close</Button>
-          </SheetClose>
+
+        {/* Composition Table */}
+        <div className="mt-2">
+          <table className="text-sm w-full border">
+            <thead>
+              <tr>
+                <th className="text-left p-1 border-b">Asset</th>
+                <th className="text-left p-1 border-b">Allocation %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {vault.composition.map((a, i) => (
+                <tr key={i}>
+                  <td className="p-1 border-b">{a.symbol}</td>
+                  <td className="p-1 border-b">{a.allocation}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {vault.staked > 0 && (
+            <div className="text-sm mt-2">Pending USDC: {vault.staked}</div>
+          )}
         </div>
+
+        {editingPrice ? (
+          <div className="flex gap-2">
+            <input
+              className="border rounded p-1 flex-1"
+              type="number"
+              value={priceValue}
+              onChange={(e) => setPriceValue(e.target.value)}
+            />
+            <Button onClick={savePrice}>Save</Button>
+            <Button variant="secondary" onClick={() => setEditingPrice(false)}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button onClick={() => setEditingPrice(true)}>Update price</Button>
+        )}
+
+        {editingComp ? (
+          <div className="space-y-2">
+            {compRows.map((row, idx) => (
+              <div key={idx} className="flex gap-2 items-center">
+                <input
+                  className="border rounded p-1 flex-1"
+                  placeholder="Asset"
+                  value={row.symbol}
+                  onChange={(e) => updateRow(idx, "symbol", e.target.value)}
+                />
+                <input
+                  className="border rounded p-1 w-20"
+                  type="number"
+                  value={row.allocation}
+                  onChange={(e) => updateRow(idx, "allocation", e.target.value)}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => removeRow(idx)}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+            <Button variant="outline" size="sm" onClick={addRow}>
+              Add asset
+            </Button>
+            <div className="flex gap-2">
+              <Button onClick={saveComp}>Save</Button>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setEditingComp(false);
+                  setCompRows(vault.composition);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button onClick={() => setEditingComp(true)}>Update composition</Button>
+        )}
+
+        <Button
+          onClick={() => {
+            onRebalance(vault.id);
+            onAction("rebalance", vault);
+          }}
+        >
+          Rebalance now
+        </Button>
+        <SheetClose asChild>
+          <Button variant="secondary">Close</Button>
+        </SheetClose>
       </SheetContent>
     </Sheet>
   );

--- a/src/components/vault/vaults.ts
+++ b/src/components/vault/vaults.ts
@@ -1,9 +1,17 @@
+export type Asset = {
+  symbol: string;
+  allocation: number;
+};
+
 export type Vault = {
   id: string;
   name: string;
   apy: number;
+  price: number;
   lastPriceUpdate: string;
   lastRebalance: string;
+  composition: Asset[];
+  staked: number; // pending USDC
 };
 
 export const vaults: Vault[] = [
@@ -11,28 +19,52 @@ export const vaults: Vault[] = [
     id: "1",
     name: "Stable Growth",
     apy: 5.2,
+    price: 100,
     lastPriceUpdate: "2024-06-01 10:00",
     lastRebalance: "2024-05-28 08:30",
+    composition: [
+      { symbol: "ETH", allocation: 50 },
+      { symbol: "BTC", allocation: 50 },
+    ],
+    staked: 500,
   },
   {
     id: "2",
     name: "Aggressive",
     apy: 12.8,
+    price: 150,
     lastPriceUpdate: "2024-06-01 11:15",
     lastRebalance: "2024-05-27 18:20",
+    composition: [
+      { symbol: "SOL", allocation: 40 },
+      { symbol: "AVAX", allocation: 60 },
+    ],
+    staked: 0,
   },
   {
     id: "3",
     name: "Income",
     apy: 3.1,
+    price: 80,
     lastPriceUpdate: "2024-05-31 16:45",
     lastRebalance: "2024-05-25 09:00",
+    composition: [
+      { symbol: "USDT", allocation: 70 },
+      { symbol: "DAI", allocation: 30 },
+    ],
+    staked: 200,
   },
   {
     id: "4",
     name: "Speculative",
     apy: 20.4,
+    price: 200,
     lastPriceUpdate: "2024-06-01 12:00",
     lastRebalance: "2024-05-20 14:50",
+    composition: [
+      { symbol: "DOGE", allocation: 50 },
+      { symbol: "PEPE", allocation: 50 },
+    ],
+    staked: 0,
   },
 ];


### PR DESCRIPTION
## Summary
- switch global font to Inter
- add composition and price fields to vault data
- create interactive vault management forms
- keep track of vault state in Dashboard

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bf9298ae88328bc9cfb39193b6ea5