### PR TITLE
Refactor UI with shadcn-inspired components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
+      <body className="antialiased bg-background text-foreground">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { VaultCard } from "@/components/vault/VaultCard";
 import { vaults, Vault, Asset } from "@/components/vault/vaults";
+import { Card } from "@/components/ui/card";
 
 interface LogEntry {
   timestamp: string;
@@ -48,7 +49,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen p-6 md:p-10 space-y-6 font-sans">
+    <div className="min-h-screen p-6 md:p-10 space-y-8 font-sans">
       <h1 className="text-2xl font-semibold">Vault overview</h1>
       <div className="grid gap-4">
         {data.map((v) => (
@@ -64,12 +65,12 @@ export default function Dashboard() {
       </div>
 
       <div>
-        <h2 className="text-xl font-semibold mt-8 mb-2">Action log</h2>
-        <ul className="text-sm space-y-1">
+        <h2 className="text-xl font-semibold mt-8 mb-4">Action log</h2>
+        <ul className="text-sm space-y-2">
           {logs.map((log, idx) => (
-            <li key={idx} className="border rounded-md p-2">
+            <Card key={idx} className="p-3">
               <span className="font-medium">{log.vault}</span> - {log.action} - {log.hash} - {log.timestamp}
-            </li>
+            </Card>
           ))}
           {logs.length === 0 && <li className="text-gray-500">No actions yet.</li>}
         </ul>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-2xl border bg-background text-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col gap-1 p-4", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-gray-300 bg-background px-3 py-1 text-sm shadow-sm ring-offset-background placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/vault/VaultCard.tsx
+++ b/src/components/vault/VaultCard.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Vault, Asset } from "./vaults";
 import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 
 interface VaultCardProps {
   vault: Vault;
@@ -51,7 +53,7 @@ export function VaultCard({
 
   return (
     <Sheet>
-      <div className="border rounded-md p-4 flex justify-between items-center">
+      <Card className="flex items-center justify-between p-4">
         <div>
           <div className="font-semibold">{vault.name}</div>
           <div className="text-sm text-gray-500">APY: {vault.apy}%</div>
@@ -59,8 +61,8 @@ export function VaultCard({
         <SheetTrigger asChild>
           <Button variant="outline" size="sm">Manage</Button>
         </SheetTrigger>
-      </div>
-      <SheetContent className="flex flex-col gap-4" side="right">
+      </Card>
+      <SheetContent className="flex flex-col gap-4 p-6" side="right">
         <div className="font-semibold text-lg mb-2">{vault.name}</div>
         <div className="text-sm">APY: {vault.apy}%</div>
         <div className="text-sm">Price: {vault.price}</div>
@@ -69,18 +71,18 @@ export function VaultCard({
 
         {/* Composition Table */}
         <div className="mt-2">
-          <table className="text-sm w-full border">
+          <table className="w-full text-sm border rounded-2xl overflow-hidden">
             <thead>
               <tr>
-                <th className="text-left p-1 border-b">Asset</th>
-                <th className="text-left p-1 border-b">Allocation %</th>
+                <th className="border-b p-1 text-left">Asset</th>
+                <th className="border-b p-1 text-left">Allocation %</th>
               </tr>
             </thead>
             <tbody>
               {vault.composition.map((a, i) => (
                 <tr key={i}>
-                  <td className="p-1 border-b">{a.symbol}</td>
-                  <td className="p-1 border-b">{a.allocation}</td>
+                  <td className="border-b p-1">{a.symbol}</td>
+                  <td className="border-b p-1">{a.allocation}</td>
                 </tr>
               ))}
             </tbody>
@@ -92,8 +94,7 @@ export function VaultCard({
 
         {editingPrice ? (
           <div className="flex gap-2">
-            <input
-              className="border rounded p-1 flex-1"
+            <Input
               type="number"
               value={priceValue}
               onChange={(e) => setPriceValue(e.target.value)}
@@ -111,14 +112,14 @@ export function VaultCard({
           <div className="space-y-2">
             {compRows.map((row, idx) => (
               <div key={idx} className="flex gap-2 items-center">
-                <input
-                  className="border rounded p-1 flex-1"
+                <Input
+                  className="flex-1"
                   placeholder="Asset"
                   value={row.symbol}
                   onChange={(e) => updateRow(idx, "symbol", e.target.value)}
                 />
-                <input
-                  className="border rounded p-1 w-20"
+                <Input
+                  className="w-20"
                   type="number"
                   value={row.allocation}
                   onChange={(e) => updateRow(idx, "allocation", e.target.value)}


### PR DESCRIPTION
## Summary
- style `RootLayout` with default background and text colors
- restyle the dashboard page and action log using new Card component
- apply soft rounded corners and subtle shadows in `VaultCard`
- replace raw form fields with reusable `Input`
- add `Card` and `Input` components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c07f745c48328806a1123807e5a88