### PR TITLE
Table based vault overview

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,15 @@
 "use client";
 import { useState } from "react";
-import { VaultCard } from "@/components/vault/VaultCard";
+import { VaultRow } from "@/components/vault/VaultRow";
 import { vaults, Vault, Asset } from "@/components/vault/vaults";
 import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+} from "@/components/ui/table";
 
 interface LogEntry {
   timestamp: string;
@@ -51,18 +58,29 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen p-6 md:p-10 space-y-8 font-sans">
       <h1 className="text-2xl font-semibold">Vault overview</h1>
-      <div className="grid gap-4">
-        {data.map((v) => (
-          <VaultCard
-            key={v.id}
-            vault={v}
-            onAction={handleAction}
-            onUpdatePrice={updatePrice}
-            onRebalance={rebalance}
-            onUpdateComposition={updateComposition}
-          />
-        ))}
-      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Vault</TableHead>
+            <TableHead>APY</TableHead>
+            <TableHead>Price</TableHead>
+            <TableHead>Last price update</TableHead>
+            <TableHead>Last rebalance</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((v) => (
+            <VaultRow
+              key={v.id}
+              vault={v}
+              onAction={handleAction}
+              onUpdatePrice={updatePrice}
+              onRebalance={rebalance}
+              onUpdateComposition={updateComposition}
+            />
+          ))}
+        </TableBody>
+      </Table>
 
       <div>
         <h2 className="text-xl font-semibold mt-8 mb-4">Action log</h2>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+));
+TableBody.displayName = "TableBody";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn("border-b transition-colors hover:bg-gray-50", className)} {...props} />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <th ref={ref} className={cn("h-12 px-4 text-left align-middle font-medium text-gray-500", className)} {...props} />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("p-4 align-middle", className)} {...props} />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn("mt-4 text-sm text-gray-500", className)} {...props} />
+));
+TableCaption.displayName = "TableCaption";
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption };

--- a/src/components/vault/VaultRow.tsx
+++ b/src/components/vault/VaultRow.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { Vault, Asset } from "./vaults";
+import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TableRow, TableCell } from "@/components/ui/table";
+
+interface VaultRowProps {
+  vault: Vault;
+  onAction: (action: string, vault: Vault) => void;
+  onUpdatePrice: (id: string, price: number) => void;
+  onRebalance: (id: string) => void;
+  onUpdateComposition: (id: string, comp: Asset[]) => void;
+}
+
+export function VaultRow({
+  vault,
+  onAction,
+  onUpdatePrice,
+  onRebalance,
+  onUpdateComposition,
+}: VaultRowProps) {
+  const [editingPrice, setEditingPrice] = useState(false);
+  const [priceValue, setPriceValue] = useState(vault.price.toString());
+
+  const [editingComp, setEditingComp] = useState(false);
+  const [compRows, setCompRows] = useState<Asset[]>(vault.composition);
+
+  const addRow = () => setCompRows((r) => [...r, { symbol: "", allocation: 0 }]);
+  const updateRow = (i: number, field: keyof Asset, value: string) => {
+    setCompRows((rows) => rows.map((r, idx) => (idx === i ? { ...r, [field]: value } : r)));
+  };
+  const removeRow = (i: number) => setCompRows((rows) => rows.filter((_, idx) => idx !== i));
+
+  const savePrice = () => {
+    onUpdatePrice(vault.id, parseFloat(priceValue));
+    onAction("update_price", vault);
+    setEditingPrice(false);
+  };
+
+  const saveComp = () => {
+    onUpdateComposition(
+      vault.id,
+      compRows.map((r) => ({ ...r, allocation: Number(r.allocation) }))
+    );
+    onAction("update_composition", vault);
+    setEditingComp(false);
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <TableRow className="cursor-pointer">
+          <TableCell className="font-medium">{vault.name}</TableCell>
+          <TableCell>{vault.apy}%</TableCell>
+          <TableCell>{vault.price}</TableCell>
+          <TableCell>{new Date(vault.lastPriceUpdate).toLocaleString()}</TableCell>
+          <TableCell>{new Date(vault.lastRebalance).toLocaleString()}</TableCell>
+        </TableRow>
+      </SheetTrigger>
+      <SheetContent className="flex flex-col gap-4 p-6" side="right">
+        <div className="font-semibold text-lg mb-2">{vault.name}</div>
+        <div className="text-sm">APY: {vault.apy}%</div>
+        <div className="text-sm">Price: {vault.price}</div>
+        <div className="text-sm">Last price update: {new Date(vault.lastPriceUpdate).toLocaleString()}</div>
+        <div className="text-sm">Last rebalance: {new Date(vault.lastRebalance).toLocaleString()}</div>
+
+        <div className="mt-2">
+          <table className="w-full text-sm border rounded-2xl overflow-hidden">
+            <thead>
+              <tr>
+                <th className="border-b p-1 text-left">Asset</th>
+                <th className="border-b p-1 text-left">Allocation %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {vault.composition.map((a, i) => (
+                <tr key={i}>
+                  <td className="border-b p-1">{a.symbol}</td>
+                  <td className="border-b p-1">{a.allocation}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {vault.staked > 0 && <div className="text-sm mt-2">Pending USDC: {vault.staked}</div>}
+        </div>
+
+        {editingPrice ? (
+          <div className="flex gap-2">
+            <Input type="number" value={priceValue} onChange={(e) => setPriceValue(e.target.value)} />
+            <Button onClick={savePrice}>Save</Button>
+            <Button variant="secondary" onClick={() => setEditingPrice(false)}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button onClick={() => setEditingPrice(true)}>Update price</Button>
+        )}
+
+        {editingComp ? (
+          <div className="space-y-2">
+            {compRows.map((row, idx) => (
+              <div key={idx} className="flex gap-2 items-center">
+                <Input
+                  className="flex-1"
+                  placeholder="Asset"
+                  value={row.symbol}
+                  onChange={(e) => updateRow(idx, "symbol", e.target.value)}
+                />
+                <Input
+                  className="w-20"
+                  type="number"
+                  value={row.allocation}
+                  onChange={(e) => updateRow(idx, "allocation", e.target.value)}
+                />
+                <Button variant="outline" size="sm" onClick={() => removeRow(idx)}>
+                  Remove
+                </Button>
+              </div>
+            ))}
+            <Button variant="outline" size="sm" onClick={addRow}>
+              Add asset
+            </Button>
+            <div className="flex gap-2">
+              <Button onClick={saveComp}>Save</Button>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setEditingComp(false);
+                  setCompRows(vault.composition);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button onClick={() => setEditingComp(true)}>Update composition</Button>
+        )}
+
+        <Button
+          onClick={() => {
+            onRebalance(vault.id);
+            onAction("rebalance", vault);
+          }}
+        >
+          Rebalance now
+        </Button>
+        <SheetClose asChild>
+          <Button variant="secondary">Close</Button>
+        </SheetClose>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary
- add shadcn Table component
- replace VaultCard with VaultRow using table row styling
- update dashboard to display vaults in table

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c0a66a4688328aa02a5d449b65b5a