### PR TITLE
Update timestamp formatting and switch to Geist font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "geist": "^1.4.2",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3762,6 +3763,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.4.2.tgz",
+      "integrity": "sha512-OQUga/KUc8ueijck6EbtT07L4tZ5+TZgjw8PyWfxo16sL5FWk7gNViPNU8hgCFjy6bJi9yuTP+CRpywzaGN8zw==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/get-intrinsic": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "geist": "^1.4.2",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: 'Inter', sans-serif;
-  --font-mono: "Courier New", monospace;
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -12,8 +14,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased bg-background text-foreground">
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <body className="antialiased bg-background text-foreground font-sans">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { VaultRow } from "@/components/vault/VaultRow";
 import { vaults, Vault, Asset } from "@/components/vault/vaults";
+import { formatTimestamp } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 import {
   Table,
@@ -87,7 +88,7 @@ export default function Dashboard() {
         <ul className="text-sm space-y-2">
           {logs.map((log, idx) => (
             <Card key={idx} className="p-3">
-              <span className="font-medium">{log.vault}</span> - {log.action} - {log.hash} - {log.timestamp}
+              <span className="font-medium">{log.vault}</span> - {log.action} - {log.hash} - {formatTimestamp(log.timestamp)}
             </Card>
           ))}
           {logs.length === 0 && <li className="text-gray-500">No actions yet.</li>}

--- a/src/components/vault/VaultRow.tsx
+++ b/src/components/vault/VaultRow.tsx
@@ -4,6 +4,7 @@ import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/s
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TableRow, TableCell } from "@/components/ui/table";
+import { formatTimestamp } from "@/lib/utils";
 
 interface VaultRowProps {
   vault: Vault;
@@ -54,16 +55,16 @@ export function VaultRow({
           <TableCell className="font-medium">{vault.name}</TableCell>
           <TableCell>{vault.apy}%</TableCell>
           <TableCell>{vault.price}</TableCell>
-          <TableCell>{new Date(vault.lastPriceUpdate).toLocaleString()}</TableCell>
-          <TableCell>{new Date(vault.lastRebalance).toLocaleString()}</TableCell>
+          <TableCell>{formatTimestamp(vault.lastPriceUpdate)}</TableCell>
+          <TableCell>{formatTimestamp(vault.lastRebalance)}</TableCell>
         </TableRow>
       </SheetTrigger>
       <SheetContent className="flex flex-col gap-4 p-6" side="right">
         <div className="font-semibold text-lg mb-2">{vault.name}</div>
         <div className="text-sm">APY: {vault.apy}%</div>
         <div className="text-sm">Price: {vault.price}</div>
-        <div className="text-sm">Last price update: {new Date(vault.lastPriceUpdate).toLocaleString()}</div>
-        <div className="text-sm">Last rebalance: {new Date(vault.lastRebalance).toLocaleString()}</div>
+        <div className="text-sm">Last price update: {formatTimestamp(vault.lastPriceUpdate)}</div>
+        <div className="text-sm">Last rebalance: {formatTimestamp(vault.lastRebalance)}</div>
 
         <div className="mt-2">
           <table className="w-full text-sm border rounded-2xl overflow-hidden">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatTimestamp(date: string | number | Date) {
+  const d = new Date(date);
+  const ds = d.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const ts = d
+    .toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    })
+    .replace(" ", "");
+  return `${ds}, ${ts}`;
+}


### PR DESCRIPTION
## Summary
- switch the app fonts to Geist
- format timestamps using a helper
- use formatted timestamps in vault tables and logs
- install Geist font package

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c0e77cb3c8328ad484314163405dd