### PR TITLE
Add slider for asset allocation editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -978,11 +979,43 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
@@ -1046,6 +1079,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1206,6 +1254,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.5.tgz",
+      "integrity": "sha512-rkfe2pU2NBAYfGaxa3Mqosi7VZEWX5CxKaanRv0vZd4Zhl9fvQrg0VM93dv3xGLGfrHuoTRF3JXH8nb9g+B3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1299,6 +1380,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-slider": "^1.3.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.4.2",

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import { cn } from "@/lib/utils";
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn("relative flex w-full touch-none select-none items-center", className)}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-gray-200">
+      <SliderPrimitive.Range className="absolute h-full bg-black" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border-2 border-black bg-white shadow focus:outline-none focus:ring-2 focus:ring-black disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/src/components/vault/VaultCard.tsx
+++ b/src/components/vault/VaultCard.tsx
@@ -4,6 +4,7 @@ import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/s
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
 
 interface VaultCardProps {
   vault: Vault;
@@ -32,6 +33,19 @@ export function VaultCard({
     setCompRows((rows) =>
       rows.map((r, idx) => (idx === i ? { ...r, [field]: value } : r))
     );
+  };
+  const updateAllocation = (i: number, value: number) => {
+    setCompRows((rows) => {
+      const otherSum = rows.reduce(
+        (sum, r, idx) => sum + (idx === i ? 0 : Number(r.allocation)),
+        0
+      );
+      const maxAllowed = 100 - otherSum;
+      const capped = Math.min(value, maxAllowed);
+      return rows.map((r, idx) =>
+        idx === i ? { ...r, allocation: capped } : r
+      );
+    });
   };
   const removeRow = (i: number) =>
     setCompRows((rows) => rows.filter((_, idx) => idx !== i));
@@ -110,29 +124,32 @@ export function VaultCard({
 
         {editingComp ? (
           <div className="space-y-2">
-            {compRows.map((row, idx) => (
-              <div key={idx} className="flex gap-2 items-center">
-                <Input
-                  className="flex-1"
-                  placeholder="Asset"
-                  value={row.symbol}
-                  onChange={(e) => updateRow(idx, "symbol", e.target.value)}
-                />
-                <Input
-                  className="w-20"
-                  type="number"
-                  value={row.allocation}
-                  onChange={(e) => updateRow(idx, "allocation", e.target.value)}
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => removeRow(idx)}
-                >
-                  Remove
-                </Button>
-              </div>
-            ))}
+            {compRows.map((row, idx) => {
+              const max = 100 - compRows.reduce((s, r, j) => s + (j === idx ? 0 : Number(r.allocation)), 0);
+              return (
+                <div key={idx} className="flex gap-2 items-center">
+                  <Input
+                    className="flex-1"
+                    placeholder="Asset"
+                    value={row.symbol}
+                    onChange={(e) => updateRow(idx, "symbol", e.target.value)}
+                  />
+                  <div className="flex items-center gap-2 w-40">
+                    <Slider
+                      value={[row.allocation]}
+                      max={max}
+                      min={0}
+                      step={1}
+                      onValueChange={(v) => updateAllocation(idx, v[0])}
+                    />
+                    <span className="w-8 text-right">{row.allocation}</span>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => removeRow(idx)}>
+                    Remove
+                  </Button>
+                </div>
+              );
+            })}
             <Button variant="outline" size="sm" onClick={addRow}>
               Add asset
             </Button>

--- a/src/components/vault/VaultRow.tsx
+++ b/src/components/vault/VaultRow.tsx
@@ -3,6 +3,7 @@ import { Vault, Asset } from "./vaults";
 import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
 import { TableRow, TableCell } from "@/components/ui/table";
 import { formatTimestamp } from "@/lib/utils";
 
@@ -30,6 +31,19 @@ export function VaultRow({
   const addRow = () => setCompRows((r) => [...r, { symbol: "", allocation: 0 }]);
   const updateRow = (i: number, field: keyof Asset, value: string) => {
     setCompRows((rows) => rows.map((r, idx) => (idx === i ? { ...r, [field]: value } : r)));
+  };
+  const updateAllocation = (i: number, value: number) => {
+    setCompRows((rows) => {
+      const otherSum = rows.reduce(
+        (sum, r, idx) => sum + (idx === i ? 0 : Number(r.allocation)),
+        0
+      );
+      const maxAllowed = 100 - otherSum;
+      const capped = Math.min(value, maxAllowed);
+      return rows.map((r, idx) =>
+        idx === i ? { ...r, allocation: capped } : r
+      );
+    });
   };
   const removeRow = (i: number) => setCompRows((rows) => rows.filter((_, idx) => idx !== i));
 
@@ -100,25 +114,32 @@ export function VaultRow({
 
         {editingComp ? (
           <div className="space-y-2">
-            {compRows.map((row, idx) => (
-              <div key={idx} className="flex gap-2 items-center">
-                <Input
-                  className="flex-1"
-                  placeholder="Asset"
-                  value={row.symbol}
-                  onChange={(e) => updateRow(idx, "symbol", e.target.value)}
-                />
-                <Input
-                  className="w-20"
-                  type="number"
-                  value={row.allocation}
-                  onChange={(e) => updateRow(idx, "allocation", e.target.value)}
-                />
-                <Button variant="outline" size="sm" onClick={() => removeRow(idx)}>
-                  Remove
-                </Button>
-              </div>
-            ))}
+            {compRows.map((row, idx) => {
+              const max = 100 - compRows.reduce((s, r, j) => s + (j === idx ? 0 : Number(r.allocation)), 0);
+              return (
+                <div key={idx} className="flex gap-2 items-center">
+                  <Input
+                    className="flex-1"
+                    placeholder="Asset"
+                    value={row.symbol}
+                    onChange={(e) => updateRow(idx, "symbol", e.target.value)}
+                  />
+                  <div className="flex items-center gap-2 w-40">
+                    <Slider
+                      value={[row.allocation]}
+                      max={max}
+                      min={0}
+                      step={1}
+                      onValueChange={(v) => updateAllocation(idx, v[0])}
+                    />
+                    <span className="w-8 text-right">{row.allocation}</span>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => removeRow(idx)}>
+                    Remove
+                  </Button>
+                </div>
+              );
+            })}
             <Button variant="outline" size="sm" onClick={addRow}>
               Add asset
             </Button>


### PR DESCRIPTION
## Summary
- add Radix Slider dependency and shadcn component
- replace number input with Slider in vault allocation editor
- prevent allocations from exceeding 100%

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c10f4c94483288e1d8832276f3476