### PR TITLE
Add table-based action log

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,21 +3,24 @@ import { useState } from "react";
 import { VaultRow } from "@/components/vault/VaultRow";
 import { vaults, Vault, Asset } from "@/components/vault/vaults";
 import { formatTimestamp } from "@/lib/utils";
-import { Card } from "@/components/ui/card";
 import {
   Table,
   TableHeader,
   TableBody,
   TableHead,
   TableRow,
+  TableCell,
 } from "@/components/ui/table";
 
 interface LogEntry {
   timestamp: string;
   vault: string;
   action: string;
-  hash: string;
+  address: string;
+  details: string;
 }
+
+const userAddress = "0x1234...abcd";
 
 export default function Dashboard() {
   const [data, setData] = useState<Vault[]>(vaults);
@@ -47,11 +50,10 @@ export default function Dashboard() {
     );
   };
 
-  function handleAction(action: string, vault: Vault) {
-    const hash = "0x" + Math.random().toString(16).slice(2, 10);
+  function handleAction(action: string, vault: Vault, details: string) {
     const timestamp = new Date().toISOString();
     setLogs((l) => [
-      { timestamp, vault: vault.name, action, hash },
+      { timestamp, vault: vault.name, action, address: userAddress, details },
       ...l,
     ]);
   }
@@ -85,14 +87,35 @@ export default function Dashboard() {
 
       <div>
         <h2 className="text-xl font-semibold mt-8 mb-4">Action log</h2>
-        <ul className="text-sm space-y-2">
-          {logs.map((log, idx) => (
-            <Card key={idx} className="p-3">
-              <span className="font-medium">{log.vault}</span> - {log.action} - {log.hash} - {formatTimestamp(log.timestamp)}
-            </Card>
-          ))}
-          {logs.length === 0 && <li className="text-gray-500">No actions yet.</li>}
-        </ul>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Date</TableHead>
+              <TableHead>Vault</TableHead>
+              <TableHead>Action</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead>Changes</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs.map((log, idx) => (
+              <TableRow key={idx}>
+                <TableCell>{formatTimestamp(log.timestamp)}</TableCell>
+                <TableCell>{log.vault}</TableCell>
+                <TableCell>{log.action}</TableCell>
+                <TableCell>{log.address}</TableCell>
+                <TableCell>{log.details}</TableCell>
+              </TableRow>
+            ))}
+            {logs.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-gray-500">
+                  No actions yet.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
       </div>
     </div>
   );

--- a/src/components/vault/VaultCard.tsx
+++ b/src/components/vault/VaultCard.tsx
@@ -8,7 +8,7 @@ import { Slider } from "@/components/ui/slider";
 
 interface VaultCardProps {
   vault: Vault;
-  onAction: (action: string, vault: Vault) => void;
+  onAction: (action: string, vault: Vault, details: string) => void;
   onUpdatePrice: (id: string, price: number) => void;
   onRebalance: (id: string) => void;
   onUpdateComposition: (id: string, comp: Asset[]) => void;
@@ -50,18 +50,33 @@ export function VaultCard({
   const removeRow = (i: number) =>
     setCompRows((rows) => rows.filter((_, idx) => idx !== i));
 
+  const compToString = (c: Asset[]) =>
+    c.map((a) => `${a.symbol} ${a.allocation}%`).join(", ");
+
   const savePrice = () => {
-    onUpdatePrice(vault.id, parseFloat(priceValue));
-    onAction("update_price", vault);
+    const newPrice = parseFloat(priceValue);
+    onUpdatePrice(vault.id, newPrice);
+    onAction(
+      "update_price",
+      vault,
+      `Price: ${vault.price} -> ${newPrice}`
+    );
     setEditingPrice(false);
   };
 
   const saveComp = () => {
-    onUpdateComposition(
-      vault.id,
-      compRows.map((r) => ({ ...r, allocation: Number(r.allocation) }))
+    const newComp = compRows.map((r) => ({
+      ...r,
+      allocation: Number(r.allocation),
+    }));
+    onUpdateComposition(vault.id, newComp);
+    onAction(
+      "update_composition",
+      vault,
+      `Composition: ${compToString(vault.composition)} -> ${compToString(
+        newComp
+      )}`
     );
-    onAction("update_composition", vault);
     setEditingComp(false);
   };
 
@@ -173,7 +188,11 @@ export function VaultCard({
         <Button
           onClick={() => {
             onRebalance(vault.id);
-            onAction("rebalance", vault);
+            onAction(
+              "rebalance",
+              vault,
+              `Staked: ${vault.staked} -> 0`
+            );
           }}
         >
           Rebalance now

--- a/src/components/vault/VaultRow.tsx
+++ b/src/components/vault/VaultRow.tsx
@@ -9,7 +9,7 @@ import { formatTimestamp } from "@/lib/utils";
 
 interface VaultRowProps {
   vault: Vault;
-  onAction: (action: string, vault: Vault) => void;
+  onAction: (action: string, vault: Vault, details: string) => void;
   onUpdatePrice: (id: string, price: number) => void;
   onRebalance: (id: string) => void;
   onUpdateComposition: (id: string, comp: Asset[]) => void;
@@ -47,18 +47,33 @@ export function VaultRow({
   };
   const removeRow = (i: number) => setCompRows((rows) => rows.filter((_, idx) => idx !== i));
 
+  const compToString = (c: Asset[]) =>
+    c.map((a) => `${a.symbol} ${a.allocation}%`).join(", ");
+
   const savePrice = () => {
-    onUpdatePrice(vault.id, parseFloat(priceValue));
-    onAction("update_price", vault);
+    const newPrice = parseFloat(priceValue);
+    onUpdatePrice(vault.id, newPrice);
+    onAction(
+      "update_price",
+      vault,
+      `Price: ${vault.price} -> ${newPrice}`
+    );
     setEditingPrice(false);
   };
 
   const saveComp = () => {
-    onUpdateComposition(
-      vault.id,
-      compRows.map((r) => ({ ...r, allocation: Number(r.allocation) }))
+    const newComp = compRows.map((r) => ({
+      ...r,
+      allocation: Number(r.allocation),
+    }));
+    onUpdateComposition(vault.id, newComp);
+    onAction(
+      "update_composition",
+      vault,
+      `Composition: ${compToString(vault.composition)} -> ${compToString(
+        newComp
+      )}`
     );
-    onAction("update_composition", vault);
     setEditingComp(false);
   };
 
@@ -163,7 +178,11 @@ export function VaultRow({
         <Button
           onClick={() => {
             onRebalance(vault.id);
-            onAction("rebalance", vault);
+            onAction(
+              "rebalance",
+              vault,
+              `Staked: ${vault.staked} -> 0`
+            );
           }}
         >
           Rebalance now


### PR DESCRIPTION
## Summary
- log vault actions with detailed description
- convert action log into a Table
- track old and new values for price, composition, and rebalances

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c1bb623888328b1572220910d624e