### PR TITLE
Add slide transition for vault panels

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -17,7 +17,8 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-300",
+      "data-[state=closed]:opacity-0",
       className
     )}
     {...props}
@@ -38,7 +39,7 @@ const SheetContent = React.forwardRef<
       ref={ref}
       {...props}
       className={cn(
-        "fixed z-50 bg-background p-6 shadow-lg transition-transform",
+        "fixed z-50 bg-background p-6 shadow-lg transition-transform duration-300",
         side === "right" &&
           "inset-y-0 right-0 w-full sm:w-96 transform data-[state=open]:translate-x-0 data-[state=closed]:translate-x-full",
         side === "left" &&


### PR DESCRIPTION
## Summary
- animate the sheet overlay and content to slide/fade on open and close

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c2391a7ac8328898c3696bf83cdc5