### PR TITLE
Add custom VaultSheet panel

### DIFF
--- a/src/components/vault/VaultCard.tsx
+++ b/src/components/vault/VaultCard.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { Vault, Asset } from "./vaults";
-import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
+import {
+  VaultSheet,
+  VaultSheetContent,
+  VaultSheetTrigger,
+  VaultSheetClose,
+} from "@/components/vault/VaultSheet";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -81,17 +86,17 @@ export function VaultCard({
   };
 
   return (
-    <Sheet>
+    <VaultSheet>
       <Card className="flex items-center justify-between p-4">
         <div>
           <div className="font-semibold">{vault.name}</div>
           <div className="text-sm text-gray-500">APY: {vault.apy}%</div>
         </div>
-        <SheetTrigger asChild>
+        <VaultSheetTrigger asChild>
           <Button variant="outline" size="sm">Manage</Button>
-        </SheetTrigger>
+        </VaultSheetTrigger>
       </Card>
-      <SheetContent className="flex flex-col gap-4 p-6" side="right">
+      <VaultSheetContent className="flex flex-col gap-4 p-6" side="right">
         <div className="font-semibold text-lg mb-2">{vault.name}</div>
         <div className="text-sm">APY: {vault.apy}%</div>
         <div className="text-sm">Price: {vault.price}</div>
@@ -197,10 +202,10 @@ export function VaultCard({
         >
           Rebalance now
         </Button>
-        <SheetClose asChild>
+        <VaultSheetClose asChild>
           <Button variant="secondary">Close</Button>
-        </SheetClose>
-      </SheetContent>
-    </Sheet>
+        </VaultSheetClose>
+      </VaultSheetContent>
+    </VaultSheet>
   );
 }

--- a/src/components/vault/VaultRow.tsx
+++ b/src/components/vault/VaultRow.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { Vault, Asset } from "./vaults";
-import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
+import {
+  VaultSheet,
+  VaultSheetContent,
+  VaultSheetTrigger,
+  VaultSheetClose,
+} from "@/components/vault/VaultSheet";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
@@ -78,8 +83,8 @@ export function VaultRow({
   };
 
   return (
-    <Sheet>
-      <SheetTrigger asChild>
+    <VaultSheet>
+      <VaultSheetTrigger asChild>
         <TableRow className="cursor-pointer">
           <TableCell className="font-medium">{vault.name}</TableCell>
           <TableCell>{vault.apy}%</TableCell>
@@ -87,8 +92,8 @@ export function VaultRow({
           <TableCell>{formatTimestamp(vault.lastPriceUpdate)}</TableCell>
           <TableCell>{formatTimestamp(vault.lastRebalance)}</TableCell>
         </TableRow>
-      </SheetTrigger>
-      <SheetContent className="flex flex-col gap-4 p-6" side="right">
+      </VaultSheetTrigger>
+      <VaultSheetContent className="flex flex-col gap-4 p-6" side="right">
         <div className="font-semibold text-lg mb-2">{vault.name}</div>
         <div className="text-sm">APY: {vault.apy}%</div>
         <div className="text-sm">Price: {vault.price}</div>
@@ -187,10 +192,10 @@ export function VaultRow({
         >
           Rebalance now
         </Button>
-        <SheetClose asChild>
+        <VaultSheetClose asChild>
           <Button variant="secondary">Close</Button>
-        </SheetClose>
-      </SheetContent>
-    </Sheet>
+        </VaultSheetClose>
+      </VaultSheetContent>
+    </VaultSheet>
   );
 }

--- a/src/components/vault/VaultSheet.tsx
+++ b/src/components/vault/VaultSheet.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@/lib/utils";
+
+const VaultSheet = DialogPrimitive.Root;
+const VaultSheetTrigger = DialogPrimitive.Trigger;
+const VaultSheetClose = DialogPrimitive.Close;
+
+const VaultSheetPortal = (props: DialogPrimitive.DialogPortalProps) => (
+  <DialogPrimitive.Portal {...props} />
+);
+VaultSheetPortal.displayName = DialogPrimitive.Portal.displayName;
+
+const VaultSheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    {...props}
+    className={cn(
+      "fixed inset-0 z-40 bg-black/50 transition-opacity data-[state=closed]:opacity-0",
+      className
+    )}
+  />
+));
+VaultSheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const VaultSheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    side?: "left" | "right";
+  }
+>(({ side = "right", className, children, ...props }, ref) => (
+  <VaultSheetPortal>
+    <VaultSheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      {...props}
+      className={cn(
+        "fixed z-50 m-4 max-w-md rounded-xl bg-white shadow transition-all duration-300 focus:outline-none",
+        "data-[state=closed]:opacity-0 data-[state=closed]:pointer-events-none",
+        side === "right" &&
+          "top-0 bottom-0 right-0 w-full translate-x-full data-[state=open]:translate-x-0",
+        side === "left" &&
+          "top-0 bottom-0 left-0 w-full -translate-x-full data-[state=open]:translate-x-0",
+        className
+      )}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </VaultSheetPortal>
+));
+VaultSheetContent.displayName = "VaultSheetContent";
+
+export { VaultSheet, VaultSheetTrigger, VaultSheetClose, VaultSheetContent };


### PR DESCRIPTION
## Summary
- introduce `VaultSheet` for sliding vault panels
- swap vault card and row management panels to use `VaultSheet`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c2873f2a0832885bf0f6b9b5656d4