### PR TITLE
Add asset value info to vault details

### DIFF
--- a/src/components/vault/VaultCard.tsx
+++ b/src/components/vault/VaultCard.tsx
@@ -10,6 +10,14 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
 
 interface VaultCardProps {
   vault: Vault;
@@ -105,22 +113,30 @@ export function VaultCard({
 
         {/* Composition Table */}
         <div className="mt-2">
-          <table className="w-full text-sm border rounded-2xl overflow-hidden">
-            <thead>
-              <tr>
-                <th className="border-b p-1 text-left">Asset</th>
-                <th className="border-b p-1 text-left">Allocation %</th>
-              </tr>
-            </thead>
-            <tbody>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Asset</TableHead>
+                <TableHead>Allocation %</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Token price</TableHead>
+                <TableHead>Total value</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {vault.composition.map((a, i) => (
-                <tr key={i}>
-                  <td className="border-b p-1">{a.symbol}</td>
-                  <td className="border-b p-1">{a.allocation}</td>
-                </tr>
+                <TableRow key={i}>
+                  <TableCell>{a.symbol}</TableCell>
+                  <TableCell>{a.allocation}</TableCell>
+                  <TableCell>{a.amount ?? "-"}</TableCell>
+                  <TableCell>{a.price ? `$${a.price}` : "-"}</TableCell>
+                  <TableCell>
+                    {a.amount && a.price ? `$${(a.amount * a.price).toLocaleString()}` : "-"}
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
           {vault.staked > 0 && (
             <div className="text-sm mt-2">Pending USDC: {vault.staked}</div>
           )}

--- a/src/components/vault/VaultRow.tsx
+++ b/src/components/vault/VaultRow.tsx
@@ -9,7 +9,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
-import { TableRow, TableCell } from "@/components/ui/table";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
 import { formatTimestamp } from "@/lib/utils";
 
 interface VaultRowProps {
@@ -101,22 +108,30 @@ export function VaultRow({
         <div className="text-sm">Last rebalance: {formatTimestamp(vault.lastRebalance)}</div>
 
         <div className="mt-2">
-          <table className="w-full text-sm border rounded-2xl overflow-hidden">
-            <thead>
-              <tr>
-                <th className="border-b p-1 text-left">Asset</th>
-                <th className="border-b p-1 text-left">Allocation %</th>
-              </tr>
-            </thead>
-            <tbody>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Asset</TableHead>
+                <TableHead>Allocation %</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Token price</TableHead>
+                <TableHead>Total value</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {vault.composition.map((a, i) => (
-                <tr key={i}>
-                  <td className="border-b p-1">{a.symbol}</td>
-                  <td className="border-b p-1">{a.allocation}</td>
-                </tr>
+                <TableRow key={i}>
+                  <TableCell>{a.symbol}</TableCell>
+                  <TableCell>{a.allocation}</TableCell>
+                  <TableCell>{a.amount ?? "-"}</TableCell>
+                  <TableCell>{a.price ? `$${a.price}` : "-"}</TableCell>
+                  <TableCell>
+                    {a.amount && a.price ? `$${(a.amount * a.price).toLocaleString()}` : "-"}
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
           {vault.staked > 0 && <div className="text-sm mt-2">Pending USDC: {vault.staked}</div>}
         </div>
 

--- a/src/components/vault/VaultSheet.tsx
+++ b/src/components/vault/VaultSheet.tsx
@@ -38,7 +38,7 @@ const VaultSheetContent = React.forwardRef<
       ref={ref}
       {...props}
       className={cn(
-        "fixed z-50 m-4 max-w-md rounded-xl bg-white shadow transition-all duration-300 focus:outline-none",
+        "fixed z-50 m-4 max-w-lg rounded-xl bg-white shadow transition-all duration-300 focus:outline-none",
         "data-[state=closed]:opacity-0 data-[state=closed]:pointer-events-none",
         side === "right" &&
           "top-0 bottom-0 right-0 w-full translate-x-full data-[state=open]:translate-x-0",

--- a/src/components/vault/vaults.ts
+++ b/src/components/vault/vaults.ts
@@ -1,6 +1,8 @@
 export type Asset = {
   symbol: string;
   allocation: number;
+  amount?: number;
+  price?: number;
 };
 
 export type Vault = {
@@ -23,8 +25,8 @@ export const vaults: Vault[] = [
     lastPriceUpdate: "2024-06-01 10:00",
     lastRebalance: "2024-05-28 08:30",
     composition: [
-      { symbol: "ETH", allocation: 50 },
-      { symbol: "BTC", allocation: 50 },
+      { symbol: "ETH", allocation: 50, amount: 10, price: 3000 },
+      { symbol: "BTC", allocation: 50, amount: 0.5, price: 65000 },
     ],
     staked: 500,
   },
@@ -36,8 +38,8 @@ export const vaults: Vault[] = [
     lastPriceUpdate: "2024-06-01 11:15",
     lastRebalance: "2024-05-27 18:20",
     composition: [
-      { symbol: "SOL", allocation: 40 },
-      { symbol: "AVAX", allocation: 60 },
+      { symbol: "SOL", allocation: 40, amount: 100, price: 25 },
+      { symbol: "AVAX", allocation: 60, amount: 80, price: 40 },
     ],
     staked: 0,
   },
@@ -49,8 +51,8 @@ export const vaults: Vault[] = [
     lastPriceUpdate: "2024-05-31 16:45",
     lastRebalance: "2024-05-25 09:00",
     composition: [
-      { symbol: "USDT", allocation: 70 },
-      { symbol: "DAI", allocation: 30 },
+      { symbol: "USDT", allocation: 70, amount: 7000, price: 1 },
+      { symbol: "DAI", allocation: 30, amount: 3000, price: 1 },
     ],
     staked: 200,
   },
@@ -62,8 +64,8 @@ export const vaults: Vault[] = [
     lastPriceUpdate: "2024-06-01 12:00",
     lastRebalance: "2024-05-20 14:50",
     composition: [
-      { symbol: "DOGE", allocation: 50 },
-      { symbol: "PEPE", allocation: 50 },
+      { symbol: "DOGE", allocation: 50, amount: 20000, price: 0.2 },
+      { symbol: "PEPE", allocation: 50, amount: 500000, price: 0.00001 },
     ],
     staked: 0,
   },


### PR DESCRIPTION
## Summary
- widen vault details panel
- add amount, price and value columns in vault details tables
- include sample amounts and prices in the demo data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c2d0b5ba08328bdcc90bde6a52407